### PR TITLE
Fixed documentation errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,17 @@
 //! Parsing expressions requires a parser to be attached to the given string.
 //!
 //! ```rust
-//! use atoms::Parser;
+//! use atoms::{Parser, StringValue};
 //! let text = "(this is a series of symbols)";
 //! let parser = Parser::new(&text);
-//! let parsed = parser.parse_basic();
+//! let parsed = parser.parse_basic().unwrap();
+//! assert_eq!(
+//!     StringValue::into_list(
+//!         vec!["this", "is", "a", "series", "of", "symbols"], 
+//!         |s| StringValue::symbol(s).unwrap()
+//!     ),
+//!     parsed
+//! );
 //! ```
 //!
 //! Custom parsing of symbols can be fairly easily defined allowing for
@@ -48,7 +55,7 @@
 //!         )
 //!     )
 //! );
-//! println!("{}", value);
+//! assert_eq!(value.to_string(), "(this \"is\" 4 . s-expression)");
 //! ```
 //!
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //! ```
 //!
 //! Custom parsing of symbols can be fairly easily defined allowing for
-//! restircted symbol sets with parsing errors. See
+//! restricted symbol sets with parsing errors. See
 //! [`Parser::parse`](struct.Parser.html#method.parse) for more.
 //!
 //! # Rendering

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -48,10 +48,17 @@ macro_rules! end_of_file {
  * Parsing expressions requires a parser to be attached to the given string.
  * 
  * ```rust
- * use atoms::Parser;
+ * use atoms::{Parser, StringValue};
  * let text = "(this is a series of symbols)";
  * let parser = Parser::new(&text);
- * let parsed = parser.parse_basic();
+ * let parsed = parser.parse_basic().unwrap();
+ * assert_eq!(
+ *     StringValue::into_list(
+ *         vec!["this", "is", "a", "series", "of", "symbols"], 
+ *         |s| StringValue::symbol(s).unwrap()
+ *     ),
+ *     parsed
+ * );
  * ```
  * 
  * The type parameter given to `Parser::parse` is to inform the parser of 
@@ -83,10 +90,17 @@ impl<'a> Parser<'a> {
      * Parse the given `str`. Consumes the parser.
      * 
      * ```rust
-     * use atoms::Parser;
+     * use atoms::{Parser, Value};
      * let text = "(this is a series of symbols)";
      * let parser = Parser::new(&text);
-     * let parsed = parser.parse::<String>();
+     * let parsed = parser.parse::<String>().unwrap();
+     * assert_eq!(
+     *     Value::into_list(
+     *         vec!["this", "is", "a", "series", "of", "symbols"], 
+     *         |s| Value::symbol(s).unwrap()
+     *     ),
+     *     parsed
+     * );
      * ```
      *
      * This parser must be informed of how to represent symbols when they are
@@ -121,10 +135,17 @@ impl<'a> Parser<'a> {
      * Parse the given `str` storing symbols as `String`s. Consumes the parser.
      * 
      * ```rust
-     * use atoms::Parser;
+     * use atoms::{Parser, StringValue};
      * let text = "(this is a series of symbols)";
      * let parser = Parser::new(&text);
-     * let parsed = parser.parse::<String>();
+     * let parsed = parser.parse::<String>().unwrap();
+     * assert_eq!(
+     *     StringValue::into_list(
+     *         vec!["this", "is", "a", "series", "of", "symbols"], 
+     *         |s| StringValue::symbol(s).unwrap()
+     *     ),
+     *     parsed
+     * );
      * ```
      *
      * In cases where no special behaviour for symbols is needed, `parse_basic`

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -118,7 +118,7 @@ impl<'a> Parser<'a> {
     }
 
     /**
-     * Parse the given `str` storing symbols as `String`s. Cosumes the parser.
+     * Parse the given `str` storing symbols as `String`s. Consumes the parser.
      * 
      * ```rust
      * use atoms::Parser;

--- a/src/value.rs
+++ b/src/value.rs
@@ -162,7 +162,7 @@ impl<Sym: Sized + ToString + FromStr> Value<Sym> {
      */
     pub fn list<V: Into<Value<Sym>>>(mut source_vec: Vec<V>) -> Value<Sym> {
 
-        // THe end of the list is a nil
+        // The end of the list is a nil
         let mut result = Value::Nil;
 
         while let Some(value) = source_vec.pop() {
@@ -211,7 +211,7 @@ impl<Sym: Sized + ToString + FromStr> Value<Sym> {
      * Create a cons cell with only a left element.
      *
      * This creates a cons cell with the right element being a nil. This is
-     * iseful it you are manually constructing lists.
+     * useful it you are manually constructing lists.
      *
      * ```rust
      * use atoms::StringValue;
@@ -254,7 +254,7 @@ impl<Sym: Sized + ToString + FromStr> Value<Sym> {
     }
 
     /**
-     * Chaeck if a value is a valid list.
+     * Check if a value is a valid list.
      *
      * A value is a list if:
      * * it is a `Value::Nil`, or


### PR DESCRIPTION
Fix up spelling in documentation and add more explanatory examples.