### PR TITLE
Version 2.2.1 - Read

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atoms"
-version = "2.2.0"
+version = "2.2.1"
 authors = ["Curtis Millar <curtis@curtism.me>", "Clark Gaebel <cg.wowus.cg@gmail.com>"]
 
 documentation = "https://docs.rs/atoms"

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 
-use std::{error, fmt, cmp};
+use std::{error, fmt};
 
 /**
  * Error that occurs when parsing s-expression.
@@ -40,27 +40,6 @@ impl ParseError {
      */
     pub fn err<T>(message: &'static str, line: usize, col: usize) -> ParseResult<T> {
         Err(ParseError::new(message, line, col))
-    }
-
-    /**
-     * Get the specified line and column in the given text that the error
-     * occurred at as a tuple.
-     *
-     * Tuple is in the form `(line, column)`.
-     */
-    #[allow(dead_code)]
-    fn get_location(s: &str, pos: usize) -> (usize, usize) {
-        let mut line: usize = 1;
-        let mut col:  isize = -1;
-        for c in s.chars().take(pos+1) {
-            if c == '\n' {
-                line +=  1;
-                col   = -1;
-            } else {
-                col  +=  1;
-            }
-        }
-        (line, cmp::max(col, 0) as usize)
     }
 }
 
@@ -106,19 +85,4 @@ fn error_display() {
 
     assert_eq!(format!("{:?}", error), "1:4: Unexpected eof");
     assert_eq!(format!("{:?}", Box::new(error)), "1:4: Unexpected eof");
-}
-
-#[test]
-fn error_location() {
-  let s = "0123456789\n0123456789\n\n6";
-  assert_eq!(ParseError::get_location(s, 4), (1, 4));
-
-  assert_eq!(ParseError::get_location(s, 10), (2, 0));
-  assert_eq!(ParseError::get_location(s, 11), (2, 0));
-  assert_eq!(ParseError::get_location(s, 15), (2, 4));
-
-  assert_eq!(ParseError::get_location(s, 21), (3, 0));
-  assert_eq!(ParseError::get_location(s, 22), (4, 0));
-  assert_eq!(ParseError::get_location(s, 23), (4, 0));
-  assert_eq!(ParseError::get_location(s, 500), (4, 0));
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,8 +15,6 @@ pub struct ParseError {
     pub line:    usize,
     /// The column number at which the error occurred.
     pub column:  usize,
-    /// The index in the given `str` at which caused the error.
-    pub index:   usize,
 }
 
 impl ParseError {
@@ -25,13 +23,11 @@ impl ParseError {
      * there is no raw error constructor
      */
     #[cold]
-    fn new(message: &'static str, source: &str, pos: usize) -> Err {
-        let (line, column) = ParseError::get_location(source, pos);
+    fn new(message: &'static str, line: usize, col: usize) -> Err {
         Box::new(ParseError {
             message: message,
             line:    line,
-            column:  column,
-            index:   pos,
+            column:  col,
         })
     }
 
@@ -42,8 +38,8 @@ impl ParseError {
      * being parsed and `pos` is the index in the `str` where the parsing error
      * occurred.
      */
-    pub fn err<T>(message: &'static str, source: &str, pos: usize) -> ParseResult<T> {
-        Err(ParseError::new(message, source, pos))
+    pub fn err<T>(message: &'static str, line: usize, col: usize) -> ParseResult<T> {
+        Err(ParseError::new(message, line, col))
     }
 
     /**
@@ -52,6 +48,7 @@ impl ParseError {
      *
      * Tuple is in the form `(line, column)`.
      */
+    #[allow(dead_code)]
     fn get_location(s: &str, pos: usize) -> (usize, usize) {
         let mut line: usize = 1;
         let mut col:  isize = -1;
@@ -105,7 +102,6 @@ fn error_display() {
         message: "Unexpected eof",
         line:    1usize,
         column:  4usize,
-        index:   4usize
     };
 
     assert_eq!(format!("{:?}", error), "1:4: Unexpected eof");


### PR DESCRIPTION
This version introduces the read functionality expected for a lisp. This
required a number of changes under the hood. Text is now buffered line by line
which should help in both REPL and reading direct from a file stream.

The code has become much tidier as a result.