### PR TITLE
Version 2.2.2: Enumerated Errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atoms"
-version = "2.2.1"
+version = "2.2.2"
 authors = ["Curtis Millar <curtis@curtism.me>", "Clark Gaebel <cg.wowus.cg@gmail.com>"]
 
 documentation = "https://docs.rs/atoms"

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,43 +5,6 @@
 
 use std::{error, fmt};
 
-/*
-pub struct ParseError {
-    /// The error that occurred
-    pub message: &'static str,
-    /// The line number at which the error occurred.
-    pub line:    usize,
-    /// The column number at which the error occurred.
-    pub column:  usize,
-}
-
-impl ParseError {
-    /**
-     * Produce a new boxed error. Errors are always used in a boxed form so
-     * there is no raw error constructor
-     */
-    #[cold]
-    fn new(message: &'static str, line: usize, col: usize) -> Err {
-        Box::new(ParseError {
-            message: message,
-            line:    line,
-            column:  col,
-        })
-    }
-
-    /**
-     * Create an `Err` containing a given error.
-     *
-     * The `message` describes what went wrong, `source` is the `str` that was
-     * being parsed and `pos` is the index in the `str` where the parsing error
-     * occurred.
-     */
-    pub fn err<T>(message: &'static str, line: usize, col: usize) -> ParseResult<T> {
-        Err(ParseError::new(message, line, col))
-    }
-}
-*/
-
 /**
  * Error that occurs when parsing s-expression.
  */

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,49 +1,126 @@
 //! Errors produced during that parsing of S-expressions
 
-#![warn(missing_docs)]
+#![deny(missing_docs)]
 #![deny(unsafe_code)]
 
 use std::{error, fmt, io};
 
 /**
  * Error that occurs when parsing s-expression.
+ *
+ * All forms of this error have the line and column the error occured on stored
+ * in the first two members respectively.
  */
 pub enum ParseError {
-    ConsParse(usize, usize),
+    /**
+     * Unexpected end of file or stream
+     *
+     * This occurs when no more characters can be read from the input stream.
+     */
     EndOfFile(usize, usize),
+    /**
+     * Trailing characters after end of expression
+     *
+     * This error is raised when trying to parseinput as a single expression
+     * and more characters are available after a full expression has been
+     * parsed. Comments after the expression do not cause this error.
+     */
     TrailingGarbage(usize, usize),
-    ClosingBrace(usize, usize),
+
+    /**
+     * Unexpected closing paren
+     *
+     * A closing paren was found as the first character of an expression.
+     */
+    ClosingParen(usize, usize),
+
+    /**
+     * Extensions not in use
+     *
+     * An extension expression was used where an extension type has not been
+     * provided.
+     */
     NoExtensions(usize, usize),
-    JoinWithoutRight(usize, usize),
+
+    /**
+     * Cons pair without right element
+     *
+     * A cons pair was closed before a right side was declared, 
+     * for example `(a . )`.
+     */
+    ConsWithoutRight(usize, usize),
+
+    /**
+     * Cons pair not closed after right expression
+     *
+     * A cons pair was not closed after the right side was declared, 
+     * for example `(a . b c)`.
+     */
     ConsWithoutClose(usize, usize),
+
+    /**
+     * An error occured when trying to parse a string literal.
+     *
+     * This is caused when the parser is unable to properly unescape a string
+     * literal.
+     */
     StringLiteral(usize, usize),
+
+    /**
+     * A symbol without any length was used.
+     *
+     * This probably caused by a quote not being attached to an expression,
+     * for example ```( ` , or ' )```
+     */
     EmptySymbol(usize, usize),
-    SymbolResolution(usize, usize),
+
+    /**
+     * Symbol could not be encoded
+     *
+     * This error is produced when a the type the represents symbols is unable
+     * to encode the given symbol.
+     */
+    SymbolEncode(usize, usize),
+
+    /**
+     * Error occured when trying to buffer text from input.
+     */
     BufferError(usize, usize, io::Error),
 }
 
 impl ParseError {
+
+    /**
+     * Get the location that an error occured on
+     *
+     * Gets the location in the form of `(line, column)`.
+     */
     pub fn position(&self) -> (usize, usize) {
         match *self {
-            ParseError::ConsParse(l, c) => (l, c),
             ParseError::EndOfFile(l, c) => (l, c),
             ParseError::TrailingGarbage(l, c) => (l, c),
-            ParseError::ClosingBrace(l, c) => (l, c),
+            ParseError::ClosingParen(l, c) => (l, c),
             ParseError::NoExtensions(l, c) => (l, c),
-            ParseError::JoinWithoutRight(l, c) => (l, c),
+            ParseError::ConsWithoutRight(l, c) => (l, c),
             ParseError::ConsWithoutClose(l, c) => (l, c),
             ParseError::StringLiteral(l, c) => (l, c),
             ParseError::EmptySymbol(l, c) => (l, c),
-            ParseError::SymbolResolution(l, c) => (l, c),
+            ParseError::SymbolEncode(l, c) => (l, c),
             ParseError::BufferError(l, c, _) => (l, c),
         }
     }
 
+    /**
+     * Get the line of input that the error occured on.
+     */
     pub fn line(&self) -> usize {
         let (line, _) = self.position();
         line
     }
 
+    /**
+     * Get the column on the line of input that the error occured on.
+     */
     pub fn column(&self) -> usize {
         let (_, column) = self.position();
         column
@@ -53,25 +130,23 @@ impl ParseError {
 impl error::Error for ParseError {
     fn description(&self) -> &str { 
         match *self {
-            ParseError::ConsParse(_, _) => 
-                "Error parsing cons or list",
             ParseError::EndOfFile(_, _) => 
                 "Unexpected end of file",
             ParseError::TrailingGarbage(_, _) => 
                 "Trailing garbage text",
-            ParseError::ClosingBrace(_, _) => 
-                "Unexpected closing brace",
+            ParseError::ClosingParen(_, _) => 
+                "Unexpected closing paren",
             ParseError::NoExtensions(_, _) => 
-                "Extensions have not yet been implemented",
-            ParseError::JoinWithoutRight(_, _) => 
+                "Extensions are not currently in use",
+            ParseError::ConsWithoutRight(_, _) => 
                 "Cons pair closed without right side",
             ParseError::ConsWithoutClose(_, _) => 
-                "Error finding close of cons",
+                "Cons pair not closed after right side",
             ParseError::StringLiteral(_, _) => 
-                "String literal escape error",
+                "Error unescaping string literal",
             ParseError::EmptySymbol(_, _) => 
-                "Empty symbol error",
-            ParseError::SymbolResolution(_, _) => 
+                "Encountered symbol with zero length",
+            ParseError::SymbolEncode(_, _) => 
                 "Error resolving symbol",
             ParseError::BufferError(_, _, _) => 
                 "Error buffering text"

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 #![warn(missing_docs)]
 #![deny(unsafe_code)]
 
-use std::{error, fmt};
+use std::{error, fmt, io};
 
 /**
  * Error that occurs when parsing s-expression.
@@ -18,7 +18,8 @@ pub enum ParseError {
     ConsWithoutClose(usize, usize),
     StringLiteral(usize, usize),
     EmptySymbol(usize, usize),
-    SymbolResolution(usize, usize)
+    SymbolResolution(usize, usize),
+    BufferError(usize, usize, io::Error),
 }
 
 impl ParseError {
@@ -33,7 +34,8 @@ impl ParseError {
             ParseError::ConsWithoutClose(l, c) => (l, c),
             ParseError::StringLiteral(l, c) => (l, c),
             ParseError::EmptySymbol(l, c) => (l, c),
-            ParseError::SymbolResolution(l, c) => (l, c)
+            ParseError::SymbolResolution(l, c) => (l, c),
+            ParseError::BufferError(l, c, _) => (l, c),
         }
     }
 
@@ -70,10 +72,17 @@ impl error::Error for ParseError {
             ParseError::EmptySymbol(_, _) => 
                 "Empty symbol error",
             ParseError::SymbolResolution(_, _) => 
-                "Error resolving symbol"
+                "Error resolving symbol",
+            ParseError::BufferError(_, _, _) => 
+                "Error buffering text"
         }
     }
-    fn cause(&self) -> Option<&error::Error> { None }
+    fn cause(&self) -> Option<&error::Error> { 
+        match *self {
+            ParseError::BufferError(_, _, ref e) => Some(e),
+            _ => None
+        }
+    }
 }
 
 /**

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -26,7 +26,7 @@ macro_rules! cons_side {
                 _ => $default,
             }
         } else {
-            parse_err!(ConsParse, $me)
+            end_of_file!($me)
         }
     }}
 }
@@ -40,7 +40,7 @@ macro_rules! cons_err {
                 _ => $me.parse_expression(),
             }
         } else {
-            parse_err!(ConsParse, $me)
+            end_of_file!($me)
         }
     }}
 }
@@ -328,7 +328,7 @@ impl<R: Read> Parser<R> {
                     self.parse_cons()
                 },
                 // End of Cons
-                ')' => parse_err!(ClosingBrace, self),
+                ')' => parse_err!(ClosingParen, self),
                 // Extension
                 '#' => parse_err!(NoExtensions, self),
                 // Quoting
@@ -385,7 +385,7 @@ impl<R: Read> Parser<R> {
             // Cons join
             try!(self.consume_comments());
             let value = cons_err!(self, 
-                ')' => JoinWithoutRight 
+                ')' => ConsWithoutRight 
             );
             if let Some(c) = try!(self.next()) {
                 if c != ')' {
@@ -503,7 +503,7 @@ impl<R: Read> Parser<R> {
         } else if let Some(sym) = Value::symbol(&text) {
             Ok(sym)
         } else {
-            parse_err!(SymbolResolution, self)
+            parse_err!(SymbolEncode, self)
         }
     }
 


### PR DESCRIPTION
This changes ParseError to an Enum. This makes it easier to handle errors from
code that uses this and also provides the location of errors more nicely.

Also introduced was the handling of errors produced when buffering input. These
are now propogated by the ParseError.

Fixes #19

Fixes #18